### PR TITLE
Changing 50-fail2ban to use zcat

### DIFF
--- a/50-fail2ban
+++ b/50-fail2ban
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 logfile='/var/log/fail2ban.log*'
-mapfile -t lines < <(grep -hioP '(\[[a-z-]+\]) (ban|unban)' $logfile | sort | uniq -c)
-jails=($(printf -- '%s\n' "${lines[@]}" | grep -oP '\[\K[^\]]+' | sort | uniq))
+mapfile -t lines < <(zgrep -hioP '(\[[a-z-]+\]) (ban|unban)' $logfile | sort | uniq -c)
+jails=($(printf -- '%s\n' "${lines[@]}" | zgrep -oP '\[\K[^\]]+' | sort | uniq))
 
 out=""
 for jail in ${jails[@]}; do
-    bans=$(printf -- '%s\n' "${lines[@]}" | grep -iP "[[:digit:]]+ \[$jail\] ban" | awk '{print $1}')
-    unbans=$(printf -- '%s\n' "${lines[@]}" | grep -iP "[[:digit:]]+ \[$jail\] unban" | awk '{print $1}')
+    bans=$(printf -- '%s\n' "${lines[@]}" | zgrep -iP "[[:digit:]]+ \[$jail\] ban" | awk '{print $1}')
+    unbans=$(printf -- '%s\n' "${lines[@]}" | zgrep -iP "[[:digit:]]+ \[$jail\] unban" | awk '{print $1}')
     diff=$(($bans-$unbans))
     out+=$(printf "$jail, %+3s bans, %+3s unbans, %+3s active" $bans $unbans $diff)"\n"
 done


### PR DESCRIPTION
Updated the 50-fail2ban script to use `zgrep` instead of `grep`.  The `zgrep` utility is provided by zutils, and it included by default in Ubuntu.  [The manpage](http://manpages.ubuntu.com/manpages/bionic/man1/zgrep.1.html) explains better, but basically it wraps grep and will automatically decompress compressed files it is handed, or just pass uncompressed files straight to grep.  The idea is that you don't have to store fail2ban logs uncompressed on disk, as your readme currently says.

Enjoy!