### PR TITLE
Remove specific paths

### DIFF
--- a/10-display-name
+++ b/10-display-name
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/figlet "$(hostname)"
+/usr/bin/env figlet "$(hostname)"

--- a/10-display-name-color
+++ b/10-display-name-color
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/figlet "$(hostname)" | /usr/games/lolcat -f
+/usr/bin/env figlet "$(hostname)" | /usr/bin/env lolcat -f

--- a/20-sysinfo
+++ b/20-sysinfo
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # get load averages
-IFS=" " read LOAD1 LOAD5 LOAD15 <<<$(/bin/cat /proc/loadavg | awk '{ print $1,$2,$3 }')
+IFS=" " read LOAD1 LOAD5 LOAD15 <<<$(cat /proc/loadavg | awk '{ print $1,$2,$3 }')
 # get free memory
 IFS=" " read USED FREE TOTAL <<<$(free -htm | grep "Mem" | awk {'print $3,$4,$2'})
 # get processes

--- a/20-uptime
+++ b/20-uptime
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 printf "\n"
-/usr/bin/uptime -p
+uptime -p


### PR DESCRIPTION
This removes the system specific paths in the scripts (didn't work for me).
Feel free to remove `/usr/bin/env` if you don't like to to it that way.
Omitting the path for all of the executables should be fine as long as the packet is installed anyway