### PR TITLE
Use `zgrep` for compressed files

### DIFF
--- a/50-fail2ban
+++ b/50-fail2ban
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 logfile='/var/log/fail2ban.log*'
-mapfile -t lines < <(grep -hioP '(\[[a-z-]+\]) (ban|unban)' $logfile | sort | uniq -c)
+mapfile -t lines < <(zgrep -hioP '(\[[a-z-]+\]) (ban|unban)' $logfile | sort | uniq -c)
 jails=($(printf -- '%s\n' "${lines[@]}" | grep -oP '\[\K[^\]]+' | sort | uniq))
 
 out=""

--- a/README.md
+++ b/README.md
@@ -18,6 +18,3 @@ option set to `yes` in your sshd config.
 
 The duplicate files are different versions of the same, use either one of them. E.g. `30-zpool-simple`
 will not print usage bars.
-
-If you use `50-fail2ban` you should comment out the `compress` option in `/etc/logrotate.d/fail2ban`,
-s.t. the logs are not compressed and can be grepped.


### PR DESCRIPTION
Thanks for putting this together @yboetz! Your work is amazing.

PREFACE: You know **a lot more** about bash than I do, so this is just a suggestion/question.

I saw at the bottom of the README that `50-fail2ban` needed a configuration change in order for it to work (because of the compressed files).

Is it possible to use [zgrep](https://linux.die.net/man/1/zgrep) instead? This is able to search compressed files without any changes to the `fail2ban` configuration.

You can see in one of my commits, I just changed it in one location and it seems to have good results for me. If you test it out and like the results, then you can simply merge this pull request.

Thanks again for all of your work! Let me know if you have any questions.