### PR TITLE
Update 50-fail2ban to use GNU zgrep to gracefully handle logrotates default gzip of old logfiles

### DIFF
--- a/50-fail2ban
+++ b/50-fail2ban
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 logfile='/var/log/fail2ban.log*'
-mapfile -t lines < <(grep -hioP '(\[[a-z-]+\]) (ban|unban)' $logfile | sort | uniq -c)
+mapfile -t lines < <(zgrep -hioP '(\[[a-z-]+\]) (ban|unban)' $logfile | sort | uniq -c)
 jails=($(printf -- '%s\n' "${lines[@]}" | grep -oP '\[\K[^\]]+' | sort | uniq))
 
 out=""


### PR DESCRIPTION
change initial file read to use zgrep [part of GNU gzip package] to gracefully handle gzipped and non-gzipped log files.

may be applicable in more places but this was the one that stood out to me.