### PR TITLE
Add links to external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Collection of my 'Message of the Day' scripts.
 ### Requirements
 
   * [update-motd](https://launchpad.net/update-motd)
-  * figlet & lolcat (for `10-display-name`)
-  * hddtemp (for `36-diskstatus`)
+  * [figlet](http://www.figlet.org/) & [lolcat](https://github.com/busyloop/lolcat) (for `10-display-name`)
+  * [hddtemp](https://savannah.nongnu.org/projects/hddtemp/) (for `36-diskstatus`)
 
 
 ### How do I set it up?

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Collection of my 'Message of the Day' scripts.
 
 ### Requirements
 
-  * update-motd
+  * [update-motd](https://launchpad.net/update-motd)
   * figlet & lolcat (for `10-display-name`)
   * hddtemp (for `36-diskstatus`)
 


### PR DESCRIPTION
I'm using Arch and `update-motd` is not present in any repository, so I had to search for it. This change adds a link back to the source code, so that we can save a few clicks :)