### PR TITLE
Exclude efivarfs from disk usage output

### DIFF
--- a/35-diskspace
+++ b/35-diskspace
@@ -11,7 +11,7 @@ dim="\e[2m"
 undim="\e[0m"
 
 # disk usage: ignore zfs, squashfs & tmpfs
-mapfile -t dfs < <(df -H -x zfs -x squashfs -x tmpfs -x devtmpfs -x overlay --output=target,pcent,size | tail -n+2)
+mapfile -t dfs < <(df -H -x zfs -x squashfs -x tmpfs -x devtmpfs -x overlay -x efivarfs --output=target,pcent,size | tail -n+2)
 printf "\ndisk usage:\n"
 
 for line in "${dfs[@]}"; do


### PR DESCRIPTION
The [efivarfs](https://docs.kernel.org/filesystems/efivarfs.html) is not meant to be used as a generic filesystem, so it can be ignored. 
